### PR TITLE
Handle rejected promise (and export boolean)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,15 @@
 			"parserOptions": {
 				"ecmaVersion": 2020,
 			},
+			"rules": {
+				"dot-notation": [2, { "allowKeywords": true }],
+			},
+		},
+		{
+			"files": "test/**/*.js",
+			"rules": {
+				"id-length": 0,
+			},
 		},
 	],
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,10 @@
 		"browser": true,
 	},
 
+	"globals": {
+		"Promise": true,
+	},
+
 	"overrides": [
 		{
 			"files": "./import.js",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.1.0](https://github.com/inspect-js/has-dynamic-import/compare/v1.0.1...v1.1.0) - 2021-05-30
+
+### Commits
+
+- [New] add `syntax` entry point that matches current main entry point [`6a1ac52`](https://github.com/inspect-js/has-dynamic-import/commit/6a1ac5209ced527eea97e529b9b9de7752fa62b8)
+- [Dev Deps] update `eslint`, `auto-changelog` [`c8c737f`](https://github.com/inspect-js/has-dynamic-import/commit/c8c737fc058eb96499e282bd4ed372490a2dcff9)
+
 ## [v1.0.1](https://github.com/inspect-js/has-dynamic-import/compare/v1.0.0...v1.0.1) - 2021-05-13
 
 ### Commits

--- a/README.md
+++ b/README.md
@@ -11,11 +11,14 @@
 
 Does the current environment have `import()` support?
 
-At the time of this writing, node v10+ has support for dynamic [`import()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#dynamic_imports);
+At the time of this writing, node v12.17+, v13.2+ and v14.0+ has support for dynamic [`import()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#dynamic_imports); the syntax is supported in node v10+.
 
-This library exports `true` if the current environment supports it, and `false` if it does not.
+The former can be checked in the package‘s main export, which is an `async function` that returns a boolean indicating if the current environment fully supports dynamic import. Note that in node v12.17 - v12.19 and v13.4 - v13.13, an ExperimentalWarning will be logged.
+
+The latter can be checked with `'has-dynamic-import/syntax'`, which is a function that returns a boolean indicating if the current environment supports parsing the syntax of dynamic import.
 
 ## Tests
+
 Simply clone the repo, `npm install`, and run `npm test`
 
 [package-url]: https://npmjs.org/package/has-dynamic-import

--- a/browser-syntax.js
+++ b/browser-syntax.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = function hasSyntax() {
+	try {
+		Function('import("").catch(() => {})'); // eslint-disable-line no-new-func
+
+		return true;
+	} catch (e) {
+		return false;
+	}
+};

--- a/browser.js
+++ b/browser.js
@@ -1,9 +1,30 @@
 'use strict';
 
-var supported = false;
-try {
-	Function('import("").catch(() => {})'); // eslint-disable-line no-new-func
-	supported = true;
-} catch (e) { /**/ }
+var callBound = require('call-bind/callBound');
+var $then = callBound('Promise.prototype.then', true);
 
-module.exports = supported;
+var pFalse = $then && Promise.resolve(false);
+var thunkFalse = function () {
+	return false;
+};
+var thunkTrue = function () {
+	return true;
+};
+
+module.exports = function hasFunctionality() {
+	if (!$then) {
+		return {
+			then: function (resolve) {
+				resolve(false);
+			}
+		};
+	}
+
+	try {
+		var promise = Function('return import("data:text/javascript,")')(); // eslint-disable-line no-new-func
+
+		return $then(promise, thunkTrue, thunkFalse);
+	} catch (e) {
+		return pFalse;
+	}
+};

--- a/import.js
+++ b/import.js
@@ -1,8 +1,7 @@
 'use strict';
 
-const fs = require('fs');
-
-module.exports = import('fs').then(
-	(x) => Object.entries(fs).every(([k, v]) => x[k] === v),
-	() => {}
-);
+module.exports = function () {
+	const promise = import('data:text/javascript,');
+	promise.catch(() => {});
+	return promise;
+};

--- a/index.js
+++ b/index.js
@@ -1,10 +1,30 @@
 'use strict';
 
+var callBound = require('call-bind/callBound');
+var $then = callBound('Promise.prototype.then', true);
+
+var pFalse = $then && Promise.resolve(false);
+var thunkFalse = function () {
+	return false;
+};
+var thunkTrue = function () {
+	return true;
+};
+
 module.exports = function hasDynamicImport() {
+	if (!$then) {
+		return {
+			then: function (resolve) {
+				resolve(false);
+			}
+		};
+	}
+
 	try {
-		require('./import'); // eslint-disable-line global-require
-		return true;
+		var importWrapper = require('./import'); // eslint-disable-line global-require
+
+		return $then(importWrapper(), thunkTrue, thunkFalse);
 	} catch (e) {
-		return false;
+		return pFalse;
 	}
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "has-dynamic-import",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"description": "Does the current environment have `import()` support?",
 	"main": "index.js",
 	"browser": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
 	"version": "1.0.1",
 	"description": "Does the current environment have `import()` support?",
 	"main": "index.js",
-	"browser": "./browser.js",
+	"browser": {
+		"./": "./browser.js",
+		"./syntax": "./browser-syntax.js"
+	},
 	"exports": {
 		".": [
 			{
@@ -11,6 +14,13 @@
 				"default": "./index.js"
 			},
 			"./index.js"
+		],
+		"./syntax": [
+			{
+				"browser": "./browser-syntax.js",
+				"default": "./syntax.js"
+			},
+			"./syntax.js"
 		],
 		"./package.json": "./package.json"
 	},
@@ -67,5 +77,11 @@
 		"commitLimit": false,
 		"backfillLimit": false,
 		"hideCredit": true
+	},
+	"dependencies": {
+		"call-bind": "^1.0.2"
+	},
+	"testling": {
+		"files": "test/index.js"
 	}
 }

--- a/syntax.js
+++ b/syntax.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = function hasSyntax() {
+	try {
+		require('./import'); // eslint-disable-line global-require
+
+		return true;
+	} catch (e) {
+		return false;
+	}
+};
+

--- a/test/index.js
+++ b/test/index.js
@@ -4,23 +4,76 @@ var test = require('tape');
 var semver = require('semver');
 var isBrowser = typeof window !== 'undefined';
 var isNode = !isBrowser && typeof process !== 'undefined';
+// eslint-disable-next-line global-require
+var spawnSync = isNode && require('child_process').spawnSync;
 
-var hasDynamicImport = require('../');
+var hasFullSupport = require('../');
 var hasSyntax = require('../syntax');
 
+var browserHasFullSupport = require('../browser');
 var browserHasSyntax = require('../browser-syntax');
 
-test('hasDynamicImport', function (t) {
-	t.equal(typeof hasDynamicImport, 'function', 'is a function');
+test('hasFullSupport', function (t) {
+	t.equal(typeof hasFullSupport, 'function', 'is a function');
 
-	var yes = hasDynamicImport();
-	t.equal(typeof yes, 'boolean', 'returns a boolean');
+	t.test('node', { skip: !isNode }, function (st) {
+		var promise = hasFullSupport();
 
-	t.test('browser', { todo: true, skip: !isBrowser }, function (st) {
-		st.end();
+		st.equal(typeof promise.then, 'function', 'returns a thenable');
+
+		promise.then(function (result) {
+			st.equal(
+				result,
+				semver.satisfies(process.version, '^12.17 || ^13.2 || >=14'),
+				'result matches expected node version range'
+			);
+
+			st.end();
+		});
 	});
 
-	t.end();
+	t.test('experimental warning', { skip: !spawnSync || process.env.RECURSION }, function (st) {
+		st.plan(1);
+		var res = spawnSync('node', ['test'], {
+			env: { PATH: process.env.PATH, RECURSION: 'recursion' }
+		});
+		if (semver.satisfies(process.version, '^12.17 <12.20 || ^13.4 < 13.14')) {
+			st.ok(String(res.stderr), 'stderr has an experimental warning in it');
+		} else {
+			st.equal(String(res.stderr), '', 'stderr is empty');
+		}
+	});
+
+	t.test('browser', function (st) {
+		var promise = browserHasFullSupport();
+
+		st.equal(typeof promise.then, 'function', 'returns a thenable');
+
+		promise.then(function (result) {
+			hasFullSupport().then(function (nodeResult) {
+				st.equal(
+					result,
+					nodeResult,
+					'matches result from node implementation'
+				);
+
+				st.end();
+			});
+		});
+	});
+
+	t.test('browser', function (st) {
+		var result = browserHasSyntax();
+
+		st.equal(typeof result, 'boolean', 'returns a boolean');
+		st.equal(
+			result,
+			hasSyntax(),
+			'matches result from node implementation'
+		);
+
+		st.end();
+	});
 });
 
 test('hasSyntax', function (t) {

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,13 @@
 
 var test = require('tape');
 var semver = require('semver');
+var isBrowser = typeof window !== 'undefined';
+var isNode = !isBrowser && typeof process !== 'undefined';
+
 var hasDynamicImport = require('../');
+var hasSyntax = require('../syntax');
+
+var browserHasSyntax = require('../browser-syntax');
 
 test('hasDynamicImport', function (t) {
 	t.equal(typeof hasDynamicImport, 'function', 'is a function');
@@ -10,18 +16,39 @@ test('hasDynamicImport', function (t) {
 	var yes = hasDynamicImport();
 	t.equal(typeof yes, 'boolean', 'returns a boolean');
 
-	t.test('browser', { todo: true, skip: typeof window === 'undefined' }, function (st) {
-		st.end();
-	});
-
-	t.test('node', { skip: typeof global === 'undefined' }, function (st) {
-		st.equal(
-			yes,
-			semver.satisfies(process.version, '>= 10'),
-			'result matches expected node version range'
-		);
+	t.test('browser', { todo: true, skip: !isBrowser }, function (st) {
 		st.end();
 	});
 
 	t.end();
+});
+
+test('hasSyntax', function (t) {
+	t.equal(typeof hasSyntax, 'function', 'is a function');
+
+	t.test('node', { skip: !isNode }, function (st) {
+		var result = hasSyntax();
+
+		st.equal(typeof result, 'boolean', 'returns a boolean');
+		st.equal(
+			result,
+			semver.satisfies(process.version, '>=10'),
+			'result matches expected node version range'
+		);
+
+		st.end();
+	});
+
+	t.test('browser', function (st) {
+		var result = browserHasSyntax();
+
+		st.equal(typeof result, 'boolean', 'returns a boolean');
+		st.equal(
+			result,
+			hasSyntax(),
+			'matches result from node implementation'
+		);
+
+		st.end();
+	});
 });


### PR DESCRIPTION
Most of the logic in this PR is discussed in #2. I also exported a boolean in the Node version as that is what the README says and also what ./browser.js does. If you prefer an exported function I can switch back to that.